### PR TITLE
feat: wheels for linux/386, linux/s390x, linux/ppc64le, windows/386

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,12 @@ jobs:
         os-arch:
           - {goos: "linux", goarch: "amd64"}
           - {goos: "linux", goarch: "arm64"}
+          - {goos: "linux", goarch: "386"}
+          - {goos: "linux", goarch: "s390x"}
+          - {goos: "linux", goarch: "ppc64le"}
           - {goos: "windows", goarch: "amd64"}
           - {goos: "windows", goarch: "arm64"}
+          - {goos: "windows", goarch: "386"}
           - {goos: "darwin", goarch: "amd64"}
           - {goos: "darwin", goarch: "arm64"}
     steps:


### PR DESCRIPTION
## Summary
- Restores `linux/386` and `windows/386` wheels (reverts the matrix portion of c642e2d).
- Adds `linux/s390x` and `linux/ppc64le` to expand PyPI architecture coverage, per #14.
- `manygo` already maps each pair to a valid wheel platform tag (`manylinux_2_17_i686`, `manylinux_2_17_s390x`, `manylinux_2_17_ppc64le`, `win32`), and Go publishes upstream archives for all four, so `hatch_build.py` works unchanged.

Closes #14

## Test plan
- [ ] Tag a release (or `workflow_dispatch`) and confirm the new matrix legs upload to PyPI.
- [ ] Verify storage usage stays within the bumped 20 GiB limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)