### PR TITLE
Use subprocesses on non-POSIX platforms

### DIFF
--- a/src/go/__init__.py
+++ b/src/go/__init__.py
@@ -8,4 +8,8 @@ def main() -> None:
     goroot = os.path.abspath(os.path.dirname(__file__))
     go_bin = os.path.join(goroot, "bin", "go")
     os.environ["GOROOT"] = goroot
-    os.execv(go_bin, [go_bin, *sys.argv[1:]])  # noqa: S606
+    if os.name == "posix":
+        os.execv(go_bin, [go_bin, *sys.argv[1:]])  # noqa: S606
+    else:
+        import subprocess
+        sys.exit(subprocess.call([go_bin, *sys.argv[1:]]))  # noqa: S603


### PR DESCRIPTION
On Windows, `os.execv` is implemented via the MSVC CRT's `_spawnv(P_OVERLAY, ...)`. That spawns a child process and immediately exits the wrapper with code 0. So any caller waiting on the wrapper's PID always sees a success, regardless of whether the `go` binary itself failed.

The pattern I've added here mirrors what other projects that call binaries do, such as Zig: https://codeberg.org/ziglang/zig-pypi/src/commit/f2b2d63cbb2e259f6fd61100c0e62af1399dcf26/make_wheels.py#L221-L231, and mine: https://github.com/agriyakhetarpal/hugo-python-distributions/blob/a45f1c886f53aa5933765200736723704b2c2476/src/hugo/cli.py#L76-L81

See also: https://arc.net/l/quote/xeztmyuo, from https://simonwillison.net/2026/Feb/4/distributing-go-binaries. Looks like they kind of built your project without seeing any prior art :(