### PR TITLE
Add Go's own license and comply with PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "go-bin"
 description = "Prebuilt golang binary"
 license = "MIT"
-license-files = ["LICENSE"]
+license-files = ["LICENSE", "go/LICENSE"]
 authors = [{ name = "Jamison Lahman", email = "jamison@lahman.dev" }]
 readme = "README.md"
 requires-python = ">=3.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ keywords = [
 ]
 classifiers = [
     "Programming Language :: Go",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@ build-backend = "hatchling.build"
 [project]
 name = "go-bin"
 description = "Prebuilt golang binary"
-license = {file = "LICENSE"}
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [{ name = "Jamison Lahman", email = "jamison@lahman.dev" }]
 readme = "README.md"
 requires-python = ">=3.6"


### PR DESCRIPTION
This PR adds Go's own license to be copied into the `.dist-info/licenses/` folder of the wheel, uses the `license` and `license-files` fields, and removes the license classifier, as it's deprecated now. All of these changes are in line with [PEP 639](https://peps.python.org/pep-0639/).