### PR TITLE
refactor(release): make PyPI publish atomic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,13 @@ on:
       - "v*.*.*"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
-  pypi:
+  build:
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -29,12 +31,37 @@ jobs:
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # ratchet:actions/setup-go@v6
         with:
           go-version: stable
+          # Each platform builds on its own runner with no persisted cache so the
+          # GOOS/GOARCH-specific go/ toolchain that hatch_build.py downloads cannot
+          # leak into another platform's wheel.
           cache: false
       - uses: astral-sh/setup-uv@ed21f2f24f8dd64503750218de024bcf64c7250a # ratchet:astral-sh/setup-uv@v7
         with:
           enable-cache: false
-      - run: |
-          GOOS="${{ matrix.os-arch.goos }}" \
-          GOARCH="${{ matrix.os-arch.goarch }}" \
+      - env:
+          MATRIX_GOOS: ${{ matrix.os-arch.goos }}
+          MATRIX_GOARCH: ${{ matrix.os-arch.goarch }}
+        run: |
+          GOOS="$MATRIX_GOOS" \
+          GOARCH="$MATRIX_GOARCH" \
           uv build --wheel
-      - run: uv publish
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
+        with:
+          name: wheels-${{ matrix.os-arch.goos }}-${{ matrix.os-arch.goarch }}
+          path: dist/*.whl
+          if-no-files-found: error
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: astral-sh/setup-uv@ed21f2f24f8dd64503750218de024bcf64c7250a # ratchet:astral-sh/setup-uv@v7
+        with:
+          enable-cache: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8
+        with:
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+      - run: uv publish dist/*


### PR DESCRIPTION
## Summary

Makes the PyPI release **atomic** by mirroring the build/publish split used in `agentic-kanban`'s release workflow.

Previously each matrix leg ran `uv build` **and** `uv publish` in the same job. If a later platform (e.g. `windows/amd64`) failed *after* an earlier one (e.g. `darwin/arm64`) had already published, PyPI was left half-published — and since PyPI rejects re-uploads of existing files, the release couldn't be cleanly retried.

## Changes

- **`build` job** (matrix): only builds + uploads per-platform wheels as artifacts.
- **`publish` job** (`needs: build`): downloads *all* wheels and runs a single `uv publish dist/*`. It runs only when every platform built successfully → all-or-nothing.
- `permissions: {}` at the top with least-privilege per job (`contents: read` for build, `id-token: write` for publish/trusted-publishing).
- Matrix values moved into `env:` to avoid template injection in the `run` step.
- `if-no-files-found: error` on upload so an empty build fails loudly instead of silently publishing nothing.

## Caching safety (`hatch_build.py`)

`hatch_build.py` caches the downloaded Go toolchain via `if not os.path.exists("go")` / `if not os.path.exists(archive)`. That's correct *within* one platform build, but it's a landmine if two platforms ever share a working directory or persisted cache — platform A's `GOOS/GOARCH`-specific `go/` toolchain would get silently bundled into platform B's wheel.

This change preserves the safe invariant: **one platform per fresh runner**, with `cache: false` (setup-go) and `enable-cache: false` (setup-uv), so no cross-platform Go toolchain state can leak between wheels.

## Validation

- YAML parses cleanly.
- `zizmor` (the repo's security gate) reports no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)